### PR TITLE
Change Gina model in ba_security2 to use hologram pushcart model.

### DIFF
--- a/src/HalfLife.UnifiedSdk.MapUpgrader.Upgrades/BlueShift/BaSecurity2ChangeHologramModelUpgrade.cs
+++ b/src/HalfLife.UnifiedSdk.MapUpgrader.Upgrades/BlueShift/BaSecurity2ChangeHologramModelUpgrade.cs
@@ -1,0 +1,22 @@
+﻿using HalfLife.UnifiedSdk.Utilities.Entities;
+using HalfLife.UnifiedSdk.Utilities.Tools.UpgradeTool;
+
+namespace HalfLife.UnifiedSdk.MapUpgrader.Upgrades.BlueShift
+{
+    /// <summary>
+    /// Changes Gina model in ba_security2 to allow playing push cart sequence.
+    /// </summary>
+    internal sealed class BaSecurity2ChangeHologramModelUpgrade : MapSpecificUpgradeAction
+    {
+        public BaSecurity2ChangeHologramModelUpgrade()
+            : base("ba_security2")
+        {
+        }
+
+        protected override void ApplyCore(MapUpgradeContext context)
+        {
+            context.Map.Entities.WhereTargetName("gina_push")
+                .FirstOrDefault()?.SetModel("models/holo_cart.mdl");
+        }
+    }
+}

--- a/src/HalfLife.UnifiedSdk.MapUpgrader.Upgrades/MapUpgradeBuilderExtensions.cs
+++ b/src/HalfLife.UnifiedSdk.MapUpgrader.Upgrades/MapUpgradeBuilderExtensions.cs
@@ -52,6 +52,7 @@ namespace HalfLife.UnifiedSdk.MapUpgrader.Upgrades
             builder.AddAction(new RemapRosenbergNoUseFlagUpgrade());
             builder.AddAction(new ChangeBlueShiftSentencesUpgrade());
             builder.AddAction(new BaXen3FixFlyBySoundsUpgrade());
+            builder.AddAction(new BaSecurity2ChangeHologramModelUpgrade());
             return builder;
         }
     }


### PR DESCRIPTION
See https://github.com/SamVanheer/halflife-unified-sdk/issues/431

The MapUpgrader has been updated to change `holo.mdl` to `holo_cart.mdl` in `ba_security2`.