### PR TITLE
Fix Rosenberg models in Blue Shift maps.

### DIFF
--- a/src/HalfLife.UnifiedSdk.MapUpgrader.Upgrades/BlueShift/BaYard1FixDeadScientistModelUpgrade.cs
+++ b/src/HalfLife.UnifiedSdk.MapUpgrader.Upgrades/BlueShift/BaYard1FixDeadScientistModelUpgrade.cs
@@ -1,0 +1,26 @@
+﻿using HalfLife.UnifiedSdk.Utilities.Entities;
+using HalfLife.UnifiedSdk.Utilities.Tools.UpgradeTool;
+
+namespace HalfLife.UnifiedSdk.MapUpgrader.Upgrades.BlueShift
+{
+    /// <summary>
+    /// Changes incorrect dead scientist head (Rosenberg) in ba_yard1 to use the same as in ba_yard4 (Glasses).
+    /// </summary>
+    internal sealed class BaYard1FixDeadScientistModelUpgrade : MapSpecificUpgradeAction
+    {
+        public BaYard1FixDeadScientistModelUpgrade()
+            : base("ba_yard1")
+        {
+        }
+
+        protected override void ApplyCore(MapUpgradeContext context)
+        {
+            foreach (var entity in context.Map.Entities
+                .OfClass("monster_scientist_dead")
+                .Where(e => e.GetInteger("body") == 3))
+            {
+                entity.SetInteger("body", 0);
+            }
+        }
+    }
+}

--- a/src/HalfLife.UnifiedSdk.MapUpgrader.Upgrades/BlueShift/ChangeRosenbergModelUpgrade.cs
+++ b/src/HalfLife.UnifiedSdk.MapUpgrader.Upgrades/BlueShift/ChangeRosenbergModelUpgrade.cs
@@ -19,9 +19,22 @@ namespace HalfLife.UnifiedSdk.MapUpgrader.Upgrades.BlueShift
                         && e.GetModel() == "models/scientist.mdl"
                         && e.GetInteger("body") == 3)))
             {
-                entity.SetModel("models/rosenberg.mdl");
-                entity.Remove("body");
+                UpdateEntity(entity);
             }
+
+            // Remap Rosenberg monster_scientist to monster_rosenberg.
+            foreach (var entity in context.Map.Entities
+                .Where(e => e.ClassName == "monster_scientist"
+                    && e.GetInteger("body") == 3))
+            {
+                entity.ClassName = "monster_rosenberg";
+                UpdateEntity(entity);
+            }
+        }
+        private static void UpdateEntity(Entity entity)
+        {
+            entity.SetModel("models/rosenberg.mdl");
+            entity.Remove("body");
         }
     }
 }

--- a/src/HalfLife.UnifiedSdk.MapUpgrader.Upgrades/BlueShift/ChangeRosenbergModelUpgrade.cs
+++ b/src/HalfLife.UnifiedSdk.MapUpgrader.Upgrades/BlueShift/ChangeRosenbergModelUpgrade.cs
@@ -1,26 +1,23 @@
 ﻿using HalfLife.UnifiedSdk.Utilities.Entities;
+using HalfLife.UnifiedSdk.Utilities.Games;
 using HalfLife.UnifiedSdk.Utilities.Tools.UpgradeTool;
-using System.Collections.Immutable;
 
 namespace HalfLife.UnifiedSdk.MapUpgrader.Upgrades.BlueShift
 {
-    internal sealed class ChangeRosenbergModelUpgrade : IMapUpgradeAction
+    internal sealed class ChangeRosenbergModelUpgrade : GameSpecificMapUpgradeAction
     {
-        private static readonly ImmutableHashSet<string> RosenbergNames = ImmutableHashSet.Create(
-            "dr_rosenberg",
-            "dr_rosenberg1",
-            "dr_rosenberg2",
-            "dr_rosenberg_fake"
-            );
+        public ChangeRosenbergModelUpgrade()
+            : base(ValveGames.BlueShift)
+        {
+        }
 
-        public void Apply(MapUpgradeContext context)
+        protected override void ApplyCore(MapUpgradeContext context)
         {
             foreach (var entity in context.Map.Entities
                 .Where(e => e.ClassName == "monster_rosenberg"
                     || (e.ClassName == "monster_generic"
                         && e.GetModel() == "models/scientist.mdl"
-                        && e.GetInteger("body") == 3
-                        && RosenbergNames.Contains(e.GetTargetName()))))
+                        && e.GetInteger("body") == 3)))
             {
                 entity.SetModel("models/rosenberg.mdl");
                 entity.Remove("body");

--- a/src/HalfLife.UnifiedSdk.MapUpgrader.Upgrades/MapUpgradeBuilderExtensions.cs
+++ b/src/HalfLife.UnifiedSdk.MapUpgrader.Upgrades/MapUpgradeBuilderExtensions.cs
@@ -46,6 +46,7 @@ namespace HalfLife.UnifiedSdk.MapUpgrader.Upgrades
 
         public static MapUpgradeBuilder AddBlueShiftUpgrades(this MapUpgradeBuilder builder)
         {
+            builder.AddAction(new BaYard1FixDeadScientistModelUpgrade());
             builder.AddAction(new BaYard4aSlavesUpgrade());
             builder.AddAction(new RenameConsoleCivAnimationsUpgrade());
             builder.AddAction(new ChangeRosenbergModelUpgrade());


### PR DESCRIPTION
See the following issues:

https://github.com/SamVanheer/halflife-unified-sdk/issues/438
https://github.com/SamVanheer/halflife-unified-sdk/issues/441

In addition, ChangeRosenbergModelUpgrade has been simplified. 

All original maps produced with the current version (master) were compared against those produced with the new changes. All files are binary identical except those affected and the only differences are the changes.

Of note, the remap of `monster_scientist` to `monster_rosenberg` occurs before the remap of monster_rosenberg `SF_ROSENBERG_NO_USE` flag, which then applies to the remapped entities, as expected.

https://github.com/SamVanheer/HalfLife.UnifiedSdk-CSharp/blob/20f0d8cb7289b16d6e97b047201c8a8530ac56ab/src/HalfLife.UnifiedSdk.MapUpgrader.Upgrades/MapUpgradeBuilderExtensions.cs#L51-L52

https://github.com/SamVanheer/HalfLife.UnifiedSdk-CSharp/blob/20f0d8cb7289b16d6e97b047201c8a8530ac56ab/src/HalfLife.UnifiedSdk.MapUpgrader.Upgrades/BlueShift/RemapRosenbergNoUseFlagUpgrade.cs#L17-L26

Changes were tested in game. No issue has been found.