### PR TITLE
Add upgrade to change bell1.wav sound and pitch.

### DIFF
--- a/src/HalfLife.UnifiedSdk.MapUpgrader.Upgrades/Common/ChangeBell1SoundAndPitch.cs
+++ b/src/HalfLife.UnifiedSdk.MapUpgrader.Upgrades/Common/ChangeBell1SoundAndPitch.cs
@@ -1,0 +1,24 @@
+﻿using HalfLife.UnifiedSdk.Utilities.Entities;
+using HalfLife.UnifiedSdk.Utilities.Tools.UpgradeTool;
+
+namespace HalfLife.UnifiedSdk.MapUpgrader.Upgrades.Common
+{
+    /// <summary>
+    /// Find all buttons/bell1.wav sounds that have a pitch set to 80.
+    /// Change those to use an alternative sound and set their pitch to 100.
+    /// </summary>
+    internal class ChangeBell1SoundAndPitch : MapUpgrade
+    {
+        protected override void ApplyCore(MapUpgradeContext context)
+        {
+            foreach (var entity in context.Map.Entities
+                .OfClass("ambient_generic")
+                .WhereString("message", "buttons/bell1.wav")
+                .Where(e => e.GetInteger("pitch") == 80))
+            {
+                entity.SetString("message", "buttons/bell1_alt.wav");
+                entity.SetInteger("pitch", 100);
+            }
+        }
+    }
+}

--- a/src/HalfLife.UnifiedSdk.MapUpgrader.Upgrades/MapUpgradeBuilderExtensions.cs
+++ b/src/HalfLife.UnifiedSdk.MapUpgrader.Upgrades/MapUpgradeBuilderExtensions.cs
@@ -39,6 +39,7 @@ namespace HalfLife.UnifiedSdk.MapUpgrader.Upgrades
             builder.AddUpgrade(new PruneExcessMultiManagerKeysUpgrade());
             builder.AddUpgrade(new AdjustMaxRangeUpgrade());
             builder.AddUpgrade(new ConvertBarneyModelUpgrade());
+            builder.AddUpgrade(new ChangeBell1SoundAndPitch());
             return builder;
         }
 


### PR DESCRIPTION
See https://github.com/SamVanheer/halflife-unified-sdk/issues/497

- Finds all occurences of `ambient_generic` with `buttons/bell1.wav` and "pitch" "80"
- Changes `buttons/bell1.wav` to `buttons/bell1_alt.wav` and "pitch" "80" to "100"

---

Tested using [UNIFIED-V1.0.0-RC002](https://github.com/SamVanheer/halflife-unified-sdk/releases/tag/UNIFIED-V1.0.0-RC002)

Tested in maps where `buttons/bell1.wav` with "pitch" "80" occur:

- t0a0
- t0a0a
- t0a0b
- t0a0b1
- t0a0b2
- t0a0c
- of3a2
- ba_hazard1
- ba_hazard2
- ba_hazard3
- ba_hazard4

---

<details>
  <summary>List of entities modified for these maps:</summary>

## t0a0.bsp

  - jump1l
  - jump2l
  - jump3l
  - duck3l
  - duck2l
  - duck1l
  - jd3l
  - jd1l
  - jd2l
  - j-d3l
  - j-d1l
  - j-d2l

## t0a0a.bsp

  - 3jumpa
  - 3jumpb
  - 3jumpc
  - ljump1
  - tower1
  - tower2
  - mom1
  - ladderdone

## t0a0b.bsp

  - targ1beep
  - targ2beep
  - targ3beep
  - targ4beep
  - targ5beep
  - targ6beep
  - crate1
  - crate2
  - gap1
  - targ7beep

## t0a0b1.bsp

  - crate1
  - crate2
  - gap1

## t0a0b2.bsp

  - targ1beep
  - targ2beep
  - targ3beep
  - targ4beep
  - targ5beep
  - targ6beep
  - targ7beep

## t0a0c.bsp

  - suit1

## of3a2.bsp

  - j-d3l
  - j-d1l
  - j-d2l

## ba_hazard1.bsp

  - jump1l
  - jump2l
  - jump3l
  - duck3l
  - duck2l
  - duck1l
  - jd3l
  - jd1l
  - jd2l
  - j-d3l
  - j-d1l
  - j-d2l

## ba_hazard2.bsp

  - snd_3jump
  - tower1
  - tower2
  - mom1
  - ladderdone

## ba_hazard3.bsp

  - crate1
  - crate2
  - gap1

## ba_hazard4.bsp

  - targ1beep
  - targ2beep
  - targ3beep
  - targ4beep
  - targ5beep
  - targ6beep
  - targ7beep

</details>